### PR TITLE
Update to latest Spike plugin devices API (for virtio devices)

### DIFF
--- a/src/virtio-9p-disk.cc
+++ b/src/virtio-9p-disk.cc
@@ -97,7 +97,7 @@ virtio9p_t::~virtio9p_t() {
 }
 
 
-std::string virtio9p_generate_dts(const sim_t* sim) {
+std::string virtio9p_generate_dts(const sim_t* sim, const std::vector<std::string>& args) {
   std::stringstream s;
   s << std::hex 
     << "    virtio9p: virtio@" << VIRTIO_9P_FS_BASE << " {\n"

--- a/src/virtio-block.cc
+++ b/src/virtio-block.cc
@@ -103,7 +103,7 @@ virtioblk_t::~virtioblk_t() {
 }
 
 
-std::string virtioblk_generate_dts(const sim_t* sim) {
+std::string virtioblk_generate_dts(const sim_t* sim, const std::vector<std::string>& args) {
   std::stringstream s;
   s << std::hex 
     << "    virtioblk: virtio@" << VIRTIO_BASE_ADDR << " {\n"


### PR DESCRIPTION
Sync with [riscv-software-src#1655](https://github.com/riscv-software-src/riscv-isa-sim/issues/1655) .